### PR TITLE
style(@julo-ui/alert): adjust container size of AlertIcon content-fit

### DIFF
--- a/packages/components/alert/src/components/alert-icon/styles.ts
+++ b/packages/components/alert/src/components/alert-icon/styles.ts
@@ -4,6 +4,8 @@ import { SystemStyleObject } from '@julo-ui/system';
 import { AlertStatus } from '../../types';
 
 export const alertIconCx = css`
+  display: flex;
+
   &[data-icon-placement='left'] {
     order: 0;
     margin-right: 0.5rem;

--- a/packages/components/form-control/tests/FormControl.spec.tsx
+++ b/packages/components/form-control/tests/FormControl.spec.tsx
@@ -120,7 +120,7 @@ describe('FormControl', () => {
     const indicator = screen.getByRole('presentation', { hidden: true });
 
     expect(input).toHaveAttribute('aria-describedby', 'firstname-helper-text');
-    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(input).toHaveAttribute('aria-invalid');
     expect(input).toHaveAttribute('aria-required', 'true');
     expect(input).toHaveAttribute('aria-readonly', 'true');
     expect(input).toHaveAttribute('aria-busy', 'true');

--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@julo-ui/react",
-  "version": "0.0.1-alpha.49",
+  "version": "0.0.1-alpha.50",
   "description": "React UI components built with React and Emotion",
   "keywords": ["react"],
   "main": "src/index.ts",


### PR DESCRIPTION
## 📝 Description

adjust AlertIcon container content-fit with icon

## ✅ Impotant things to be checked

 - [x] update @julo-ui/react version (important)

## ⛳️ Current behavior (updates)

![image](https://github.com/julofinance/julo-ui/assets/42550309/a24f4985-670c-44ee-9e04-9fdd0ff1f8b8)

## 🚀 New behavior

![image](https://github.com/julofinance/julo-ui/assets/42550309/7e96078f-71cb-4672-b2ea-78b0eeb2c75e)

